### PR TITLE
Bug fix of image deletion

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1518,6 +1518,10 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def delete_image(self):
         delete_path = self.file_path
+        if (self.cur_img_idx + 1) == self.img_count:
+            self.open_prev_image()
+        else:
+            self.open_next_image()
         if delete_path is not None:
             idx = self.cur_img_idx
             if os.path.exists(delete_path):


### PR DESCRIPTION
This is a fix for a bug in the labelImg.py file that will allow you to continue annotating instead of taking you back to the first image of your dataset after an image deletion.